### PR TITLE
Fixed line breaks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ Compiling and installing morpheus
 ---------------------------------
 
 By default morpheus installs into bin/
-
+```
   cd src
   make
   make install
-
+```
 Compiling a stem library
 ------------------------
-
+```
   cd stemlib/Latin
   export PATH=$PATH:../../bin
   MORPHLIB=.. make
-
+```
 Running the cruncher
 --------------------
-
+```
 MORPHLIB=stemlib bin/cruncher < wordlist > crunched
+```


### PR DESCRIPTION
I made a small change to fix the line breaks in the README by putting the relevant sections in code blocks.